### PR TITLE
simplify datetime handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 rfc6266 = "^0.0.4"
-tzlocal = "^2.0.0"
 iso8601 = "^0.1.12"
 docopt = "^0.6.2"
 pydash = "^4.7.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 rfc6266
-tzlocal
 iso8601
 docopt
 pydash


### PR DESCRIPTION
- remove tzlocal and replace it with std lib solution
- don't skip unparseable dates, but replace them with 1970-01-01