### PR TITLE
Fix poetry build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,5 +42,5 @@ pattern = '^v(?P<base>\d+\.\d+)'
 format = '{base}.{distance}'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = ["poetry.masonry.api", "poetry-dynamic-versioning"]
+requires = ["poetry>=1.0.2", "poetry-dynamic-versioning"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Fixes build error. See the docs for poetry-dynamic-versioning here https://pypi.org/project/poetry-dynamic-versioning/

```
mtv_dl>py -m pip install .

Processing mtv_dl
  Installing build dependencies ... done
  Getting requirements to build wheel ...   ERROR: Error environment can only contain strings while executing command Getting requirements to build wheel
error
ERROR: Exception:
Traceback (most recent call last):
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\cli\base_command.py", line 167, in exc_logging_wrapper
    status = run_func(*args)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\cli\req_command.py", line 205, in wrapper
    return func(self, options, args)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\commands\install.py", line 339, in run
    requirement_set = resolver.resolve(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\resolver.py", line 75, in resolve
    collected = self.factory.collect_root_requirements(root_reqs)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 506, in collect_root_requirements
    req = self._make_requirement_from_install_req(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 468, in _make_requirement_from_install_req
    cand = self._make_candidate_from_link(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\factory.py", line 215, in _make_candidate_from_link
    self._link_candidate_cache[link] = LinkCandidate(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 288, in __init__
    super().__init__(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 158, in __init__
    self.dist = self._prepare()
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 227, in _prepare
    dist = self._prepare_distribution()
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\resolution\resolvelib\candidates.py", line 299, in _prepare_distribution
    return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\operations\prepare.py", line 487, in prepare_linked_requirement
    return self._prepare_linked_requirement(req, parallel_builds)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\operations\prepare.py", line 556, in _prepare_linked_requirement
    dist = _get_prepared_distribution(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\operations\prepare.py", line 58, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\distributions\sdist.py", line 45, in prepare_distribution_metadata
    self._install_build_reqs(finder)
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\distributions\sdist.py", line 104, in _install_build_reqs
    build_reqs = self._get_build_requires_wheel()
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\distributions\sdist.py", line 81, in _get_build_requires_wheel
    return backend.get_requires_for_build_wheel()
  File "D:\APPS\Python38\lib\site-packages\pip\_vendor\pep517\wrappers.py", line 172, in get_requires_for_build_wheel
    return self._call_hook('get_requires_for_build_wheel', {
  File "D:\APPS\Python38\lib\site-packages\pip\_vendor\pep517\wrappers.py", line 322, in _call_hook
    self._subprocess_runner(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\utils\subprocess.py", line 252, in runner
    call_subprocess(
  File "D:\APPS\Python38\lib\site-packages\pip\_internal\utils\subprocess.py", line 141, in call_subprocess
    proc = subprocess.Popen(
  File "D:\APPS\Python38\lib\subprocess.py", line 858, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "D:\APPS\Python38\lib\subprocess.py", line 1311, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
TypeError: environment can only contain strings
```