### PR TITLE
Use 1970-01-03 for windows instead of 1970-01-01 to make timestamp work in all timezone cases

### DIFF
--- a/mtv_dl.py
+++ b/mtv_dl.py
@@ -542,8 +542,9 @@ class Database(object):
                                     # The datetime.fromtimestamp call may fail because there are issues
                                     # with very old timestamps on Windows. See: https://bugs.python.org/issue36439
                                     # On some platforms, dates not within 1970 through 2038 may overflow (see issue #42).
-                                    # These episodes will be assigned a default date of 1970-01-01
-                                    start = datetime.fromtimestamp(0, tz=utc_zone)
+                                    # These episodes will be assigned a default date of 1970-01-02.
+                                    # With a smaller timedelta, timestamp() might fail on Windows.
+                                    start = datetime.fromtimestamp(0, tz=utc_zone) + timedelta(days=2)
                                 duration = timedelta(seconds=self._duration_in_seconds(show['duration']))
                                 yield {
                                     'hash': self._show_hash(channel, topic, title, size, start.replace(tzinfo=None)),


### PR DESCRIPTION
Hi, sorry your commit https://github.com/fnep/mtv_dl/commit/6900fdcc8083c17ff5a4f3a6d4e4a59d924fd828 broke timestamp() on Windows again... I have now idea why the timestamp handling code is so broken in Python on Windows.

Adding 32 hours to the minimum timestamp seems to solve the issue on my machine and keep the original hash at the same time. So I added 2 days to be sure. 32 hours might be an artifact of my local timezone.

Just fyi
```
>>> for i in range(100):
...  try:
...   print((datetime.fromtimestamp(0, tz=timezone.utc) + timedelta(hours=i)).replace(tzinfo=None).timestamp())
...  except Exception as e:
...   print(i, e)
...
0 [Errno 22] Invalid argument
1 [Errno 22] Invalid argument
2 [Errno 22] Invalid argument
3 [Errno 22] Invalid argument
4 [Errno 22] Invalid argument
5 [Errno 22] Invalid argument
6 [Errno 22] Invalid argument
7 [Errno 22] Invalid argument
8 [Errno 22] Invalid argument
9 [Errno 22] Invalid argument
10 [Errno 22] Invalid argument
11 [Errno 22] Invalid argument
12 [Errno 22] Invalid argument
13 [Errno 22] Invalid argument
14 [Errno 22] Invalid argument
15 [Errno 22] Invalid argument
16 [Errno 22] Invalid argument
17 [Errno 22] Invalid argument
18 [Errno 22] Invalid argument
19 [Errno 22] Invalid argument
20 [Errno 22] Invalid argument
21 [Errno 22] Invalid argument
22 [Errno 22] Invalid argument
23 [Errno 22] Invalid argument
24 [Errno 22] Invalid argument
25 [Errno 22] Invalid argument
26 [Errno 22] Invalid argument
27 [Errno 22] Invalid argument
28 [Errno 22] Invalid argument
29 [Errno 22] Invalid argument
30 [Errno 22] Invalid argument
31 [Errno 22] Invalid argument
86400.0
90000.0
93600.0
97200.0
...
```