### PR TITLE
Remove outdated encoding hack

### DIFF
--- a/mtv_dl.py
+++ b/mtv_dl.py
@@ -1189,12 +1189,6 @@ def main() -> None:
                                                                  width=80,
                                                                  subsequent_indent=' ' * 4)))
 
-    # broken console encoding handling  (http://archive.is/FRcJe#60%)
-    if sys.stdout.encoding != 'UTF-8':
-        sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')  # type: ignore
-    if sys.stderr.encoding != 'UTF-8':
-        sys.stderr = codecs.getwriter('utf-8')(sys.stderr.buffer, 'strict')  # type: ignore
-
     # rfc6266 logger fix (don't expect an upstream fix for that)
     for logging_handler in rfc6266.LOGGER.handlers:
         rfc6266.LOGGER.removeHandler(logging_handler)


### PR DESCRIPTION
It breaks rich logging on Windows.

Eg.
```
←[2K←[1;34mDownloading database←[0m ←[30m-------------------------------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[30m-------------------------------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[30m-------------------------------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m ←[0m←[30m---------------------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m-←[0m←[30m ←[0m←[30m-----------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m-←[0m←[91m ←[0m←[30m-----------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m--←[0m←[30m ←[0m←[30m----------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m---←[0m←[91m ←[0m←[30m---------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m----←[0m←[91m ←[0m←[30m--------------------------------------------------------←[2K←[1;34mDownloading database←[0m ←[91m-----←[0m←[91m ←[0m←[30m-------------------------------------------------------
```
