### PR TITLE
Improve memory usage

### DIFF
--- a/mtv_dl.py
+++ b/mtv_dl.py
@@ -341,7 +341,7 @@ class Database(object):
         logger.debug('Initializing Filmliste database in %r.', self.database_file('main'))
         cursor = self.connection.cursor()
         try:
-            cursor.execute("""        
+            cursor.execute("""
                 CREATE TABlE main.show (
                     hash TEXT,
                     channel TEXT,
@@ -548,7 +548,7 @@ class Database(object):
                             if show['start'] and show['url']:
                                 title = show['title']
                                 size = int(show['size']) if show['size'] else 0
-                                
+
                                 # this should work on all platforms.
                                 # See https://github.com/fnep/mtv_dl/issues/42 or https://bugs.python.org/issue36439
                                 start = datetime.fromtimestamp(0, tz=utc_zone) + timedelta(seconds=int(show['start']))
@@ -1118,7 +1118,7 @@ class Downloader:
                 if self.show['start']:
                     ET.SubElement(nfo_movie, 'aired').text = self.show['start'].isoformat()
                 ET.SubElement(nfo_movie, 'country').text = self.show['region']
-                
+
                 with NamedTemporaryFile(mode='wb', prefix='.tmp', dir=temp_path, delete=False) as out_fh:
                     nfo_path = Path(temp_path) / out_fh.name
                     out_fh.write(ET.tostring(nfo_movie, xml_declaration=True, encoding="UTF-8"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ PyYAML = "^6.0"
 beautifulsoup4 = "^4.10.0"
 rich = "^12.0.0"
 certifi = "^2021.10.8"
+ijson = "^3.1.4"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.941"


### PR DESCRIPTION
Before, the Filmliste was read by loading and parsing the whole json
in-memory. On restricted platforms, this led to prohibitive memory use.

This commit instead uses ijson, a iterative / streaming json parser
posing as a python generator, instead. This improves memory usage from
~1700MB down to ~140MB peak. See the attached SVGs for details.

As for performance — especially since we need to loop over the whole list of entries in the `json` twice — it seems there isn’t much degredation, I measured (and unfortunately my system was not completely idle, so allow for a bit of jitter):
```
# patched with progress bar
real	0m43.728s
user	0m36.373s
sys	0m1.236s

# patched progress bar hidden
real	0m39.642s
user	0m31.702s
sys	0m1.427s


# current master
real	0m41.470s
user	0m32.361s
sys	0m2.163s
```

While a bit degraded, I think it’s fine.

As for compatability, as far as I could see, `ijson` builds binary wheels for `arm64` too, and failing that users can install necessary build dependencies and `pip` will build the `C`-part by itself.


![peak-memory-original](https://user-images.githubusercontent.com/6271072/159530064-847c0519-e631-4204-99dc-76b2556ff06a.svg)
![peak-memory-optimized](https://user-images.githubusercontent.com/6271072/159530067-2fc2daf5-154b-4c7c-93f6-15e4a15ced08.svg)

Fixes #51 