### PR TITLE
added github action for container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,59 @@
+name: container
+
+on:
+  push:
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+  # base path to the dockerfile
+  DOCKERFILE_PATH: .
+  # build platform
+  BUILD_PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  build-container:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: ${{ env.DOCKERFILE_PATH }}
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I have noticed, that your docker hub container images were not updated since about 2 years.
Because of this I have created this simple github action.

It will automatically build new container images, if you push to your master branch (docker tag: master) or if you tag your code (docker tags: vX.XX and latest)
With the current code it will push the container to the github container registry. (I prefer this one, since docker hub have rate limits). Of course you can change it, to push the images to docker hub.

the containers are currently build for x86_64 and arm64 arch.