### PR TITLE
Implementation of series feature

### DIFF
--- a/mtv_dl.py
+++ b/mtv_dl.py
@@ -205,7 +205,7 @@ __version__ = "0.0.0"
 CHUNK_SIZE = 128 * 1024
 
 HIDE_PROGRESSBAR = True
-CAFILE = None
+CAFILE = None # type: Optional[str]
 DEFAULT_CONFIG_FILE = Path('~/.mtv_dl.yml')
 CONFIG_OPTIONS = {
     'count': int,
@@ -429,7 +429,7 @@ class Database(object):
                     UNIQUE (hash)
                 );
             """)
-            cursor.execute(f'PRAGMA history.user_version=2')
+            cursor.execute('PRAGMA history.user_version=2')
         elif self.history_version == 1:       
             logger.info('Upgrading history database schema, adding columns for season and episode')
             # manually control transactions to make sure this schema upgrade is atomic
@@ -439,7 +439,7 @@ class Database(object):
             cursor.execute("BEGIN")
             cursor.execute("ALTER TABLE history.downloaded ADD COLUMN season INTEGER")
             cursor.execute("ALTER TABLE history.downloaded ADD COLUMN episode INTEGER")
-            cursor.execute(f'PRAGMA history.user_version=2')
+            cursor.execute('PRAGMA history.user_version=2')
             cursor.execute("COMMIT")
             self.connection.isolation_level = old_isolation_level
 
@@ -1318,8 +1318,8 @@ def run_post_download_hook(executable: Path, item: Database.Item, downloaded_fil
                            "MTV_DL_WEBSITE":  item['website'],
                            "MTV_DL_START":  item['start'].isoformat(),
                            "MTV_DL_DURATION":  str(item['duration'].total_seconds()),
-                           "MTV_DL_SEASON":  item['season'],
-                           "MTV_DL_EPISODE":  item['episode'],
+                           "MTV_DL_SEASON":  str(item['season']),
+                           "MTV_DL_EPISODE":  str(item['episode']),
                        },
                        encoding="utf-8")
     except subprocess.CalledProcessError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ format = '{base}.{distance}'
 
 [tool.ruff]
 line-length = 120
+exclude = [".venv"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ ijson
 iso8601
 PyYAML
 rich
+typing-extensions
+ijson
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ rich
 typing-extensions
 ijson
 pytest
+pytest-ruff
+pytest-mypy
+types-PyYAML


### PR DESCRIPTION
Start of the implementation of a "series" feature as discussed in #60 .

This feature provides:
* new flag "--series" to toggle the behavior
* extracting season/episode information from the title of the show for two cases: "(Sxx/Eyy)" and "(xx)". Other patterns need to be added once we see them being used.
* adding two new variables to the `--target flag` to name files based on {{season}} and {{episode}}

What is *not* implemented:
* Support filterining shows by season/episode, not sure if we want to have that.
* Showing the season/episode information in the `list/dump` output.
* Assigning a different default `--target` name in `--series` mode

Please let me know what you think and if/in what direction to keep moving.

⚠️ This PR also contains a simple `test.sh` script to test the new behavior. We need to strip this file before merging.
