### PR TITLE
update build-system according to poetry-dynamic-versioning docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ format = '{base}.{distance}'
 line-length = 120
 
 [build-system]
-requires = ["poetry>=1.0.2", "poetry-dynamic-versioning"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
According to https://pypi.org/project/poetry-dynamic-versioning/ this is the latest way to use it now. This fixes ediable installs via pip for example.