### PR TITLE
Bump iso8601 from 1.1.0 to 2.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -552,13 +552,13 @@ files = [
 
 [[package]]
 name = "iso8601"
-version = "1.1.0"
+version = "2.1.0"
 description = "Simple module to parse ISO 8601 dates"
 optional = false
-python-versions = ">=3.6.2,<4.0"
+python-versions = ">=3.7,<4.0"
 files = [
-    {file = "iso8601-1.1.0-py3-none-any.whl", hash = "sha256:8400e90141bf792bce2634df533dc57e3bee19ea120a87bebcd3da89a58ad73f"},
-    {file = "iso8601-1.1.0.tar.gz", hash = "sha256:32811e7b81deee2063ea6d2e94f8819a86d1f3811e49d23623a41fa832bef03f"},
+    {file = "iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242"},
+    {file = "iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df"},
 ]
 
 [[package]]
@@ -1234,4 +1234,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d17fbaae324f59586fd2dcd5773b8da9bc3e2dcedc0c3e511eec3074436ff158"
+content-hash = "ca716493bacb4ef78880738ddc86ca2b0926b6e8e4ee186115b2d8273b924dbc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-iso8601 = "^1.1.0"
+iso8601 = "^2.1.0"
 docopt = "^0.6.2"
 durationpy = "0.5"
 PyYAML = "^6.0"


### PR DESCRIPTION
Version bump. I'm not really familiar with the python ecosystem so let me know if I'm doing something wrong (or forgetting something) here.