### PR TITLE
Fix "--dir" option in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ channel=ZDF topic=heute-show duration+20m
 ```
 
 ```shell
-❯ mtv_dl download --dir=/media --high --target='{dir}/{channel}/[{topic} {date}] {title}{ext}' --sets=shows.txt
+❯ mtv_dl --dir=/media download --high --target='{dir}/{channel}/[{topic} {date}] {title}{ext}' --sets=shows.txt
 ```
 
 ### Use a config file to apply useful defaults for all commands


### PR DESCRIPTION
Hey there,

First: Thanks for providing this nice small software package :-)

Previously I used "mtv_dl download --dir=/tmp ....". This stopped working with the new versions.
No I need to do this: "mtv_dl --dir=/tmp download ..."

Maybe this is not intended behaviour and a regression. If it is intended, then here is a PR to fix the documentation :-)

Best regards
Entepotenz